### PR TITLE
Eliminate potential conflict

### DIFF
--- a/src/Async.kt
+++ b/src/Async.kt
@@ -31,7 +31,7 @@ fun Application.async(random: Random = Random(), delayProvider: DelayProvider = 
 
 private suspend fun ApplicationCall.respondHandlingLongCalculation(random: Random, delayProvider: DelayProvider, startTime: Long) {
     val queueTime = System.currentTimeMillis() - startTime
-    var number = 0
+    var number = AtomicInteger()
     val computeTime = measureTimeMillis {
         // We specify a coroutine context, that will use a thread pool for long computing operations.
         // In this case it is not necessary since we are "delaying", not sleeping the thread.
@@ -40,7 +40,7 @@ private suspend fun ApplicationCall.respondHandlingLongCalculation(random: Rando
         withContext(compute) {
             for (index in 0 until 300) {
                 delayProvider(10)
-                number += random.nextInt(100)
+                number.addAndGet(random.nextInt(100))
             }
         }
     }


### PR DESCRIPTION
`number` is in a critical section as modified by multiple threads - there is a possibility that two threads will try to modify it at the same time and so the result is uncertain. It either needs to be synchronized with `Mutex`, channel, or we need to use `AtomicInteger`.